### PR TITLE
changes run name to be optional for list commands

### DIFF
--- a/api/graphql/schema.graphql
+++ b/api/graphql/schema.graphql
@@ -1,6 +1,6 @@
 type OmicsListRunCommand @aws_cognito_user_pools(cognito_groups: ["admin", "bioinformatician"]) {
-  name: String!
-  id: String
+  name: String
+  id: String!
   arn: String
   creationTime: AWSDateTime
   priority: String
@@ -43,8 +43,8 @@ type OmicsListRunTasks @aws_cognito_user_pools(cognito_groups: ["admin", "bioinf
 }
 
 type OmicsListRunDetails @aws_cognito_user_pools(cognito_groups: ["admin", "bioinformatician"]) {
-  name: String!
-  id: String
+  name: String
+  id: String!
   arn: String
   creationTime: AWSDateTime
   priority: String


### PR DESCRIPTION
*Issue:*

Workflow run names are not required by HealthOmics. Therefore it is possible to create a run via the CLI or API calls that doesn't have a name. The GraphQL schema for `OmicsListRunCommand` and `OmicsListRunDetails` require the `name` to be not null. This can produce errors in the UI when retrieving runs.

*Description of changes:*
Makes `name` optional and requires `id` (which cannot be null).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
